### PR TITLE
Add CoinGecko API for Current ETH Price

### DIFF
--- a/artblocks_processing.ipynb
+++ b/artblocks_processing.ipynb
@@ -10,7 +10,9 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "import plotly.express as px\n",
-    "import kaleido"
+    "import kaleido\n",
+    "from pycoingecko import CoinGeckoAPI\n",
+    "cg = CoinGeckoAPI()"
    ]
   },
   {
@@ -21,8 +23,8 @@
    "source": [
     "# Select start date\n",
     "start_date = \"2022-01-01\"\n",
-    "# Input current price of ETH\n",
-    "ethusd = 2683\n",
+    "# Get current price of ETH\n",
+    "ethusd = cg.get_price(ids='ethereum', vs_currencies='usd')\n",
     "# Initialize collection slugs\n",
     "slugs = [\n",
     "#     \"anticyclone-by-william-mapan\",\n",


### PR DESCRIPTION
Add CoinGecko API for Current ETH Price

Might be possible to add this so current ETH prices do not need to be manually entered

Does output as Dict so would possibly need to extract float before merging this***